### PR TITLE
chore: move travis config to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+step-restore-cache: &step-restore-cache
+  restore_cache:
+    keys:
+      - v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+      - v1-dependencies-{{ arch }}
+
+steps-test: &steps-test
+  steps:
+    - checkout
+    - *step-restore-cache
+    - run: yarn --frozen-lockfile
+    - save_cache:
+        paths:
+          - node_modules
+        key: v1-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}
+    - run: yarn build
+    - run: yarn test
+
+version: 2.1
+jobs:
+  test:
+    macos:
+      xcode: "12.2.0"
+    <<: *steps-test
+
+  release:
+    docker:
+      - image: circleci/node:14.15
+    steps:
+      - checkout
+      - *step-restore-cache
+      - run: yarn --frozen-lockfile
+      - run: npx semantic-release
+workflows:
+  version: 2
+  test_and_release:
+    jobs:
+      - test
+      - release:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - master

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ jspm_packages
 .node_repl_history
 
 # lock files
-yarn.lock
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "semantic-release": "semantic-release",
     "test": "tape test/index.js",
-    "travis-deploy-once": "travis-deploy-once",
     "update-abi-registry": "node --unhandled-rejections=strict scripts/update-abi-registry.js"
   },
   "repository": {
@@ -29,8 +28,7 @@
   "devDependencies": {
     "got": "^10.6.0",
     "semantic-release": "^15.8.0",
-    "tape": "^4.6.3",
-    "travis-deploy-once": "^5.0.1"
+    "tape": "^4.6.3"
   },
   "dependencies": {
     "semver": "^5.4.1"


### PR DESCRIPTION
This PR removes the previous Travis config and starts the release automation on Electron's CircleCI jobs.