### PR TITLE
chore: change master branch to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,4 +54,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,5 +5,5 @@
       "@continuous-auth/semantic-release-npm",
       "@semantic-release/github"
     ],
-    "branches": [ "master" ]
+    "branches": [ "main" ]
   }


### PR DESCRIPTION
This PR updates all areas where "master" is hardcoded as the trunk branch to "main", allowing us to change trunk.