### PR TITLE
fix: update node 17 to 17.0.1

### DIFF
--- a/abi_registry.json
+++ b/abi_registry.json
@@ -52,7 +52,7 @@
   },
   {
     "runtime": "node",
-    "target": "17.0.0",
+    "target": "17.0.1",
     "lts": false,
     "future": false,
     "abi": "102"


### PR DESCRIPTION
Fixes #114

In Node 17.0.0, a header is missing and causes an error during compilation. This was a [known problem](https://github.com/nodejs/node/issues/40529) solved in version 17.0.1; this PR updates the target to point at the fixed version.