### PR TITLE
fix: let Node.js v17.0.0 be ovverrided by v17.0.1

### DIFF
--- a/abi_registry.json
+++ b/abi_registry.json
@@ -52,7 +52,7 @@
   },
   {
     "runtime": "node",
-    "target": "17.0.0",
+    "target": "17.0.1",
     "lts": false,
     "future": false,
     "abi": "102"

--- a/scripts/update-abi-registry.js
+++ b/scripts/update-abi-registry.js
@@ -17,6 +17,14 @@ async function fetchNodeVersions () {
   const schedule = await getJSONFromCDN('nodejs/Release/schedule.json')
   const versions = {}
 
+  // The target is set to X.0.0 by default, where X is the major version.
+  // Use targetOverride to specify a different target.
+  const targetOverride = {
+    // In Node 17.0.0, a header is missing and causes an error during compilation.
+    // See https://github.com/electron/node-abi/issues/114
+    '17.0.0': '17.0.1'
+  }
+
   for (const [majorVersion, metadata] of Object.entries(schedule)) {
     if (majorVersion.startsWith('v0')) {
       continue
@@ -25,7 +33,7 @@ async function fetchNodeVersions () {
     const lts = metadata.hasOwnProperty('lts') ? [metadata.lts, metadata.maintenance] : false
     versions[version] = {
       runtime: 'node',
-      target: version,
+      target: targetOverride.hasOwnProperty(version) ? targetOverride[version] : version,
       lts: lts,
       future: new Date(Date.parse(metadata.start)) > new Date()
     }

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,8 @@ test('getTarget calculates correct Node target', function (t) {
   t.equal(getTarget('72'), '12.0.0')
   t.equal(getTarget('83'), '14.0.0')
   t.equal(getTarget('88'), '15.0.0')
+  t.equal(getTarget('93'), '16.0.0')
+  t.equal(getTarget('102'), '17.0.1')
   t.end()
 })
 


### PR DESCRIPTION
Since #119 has been closed before being merge, I make this PR in order to (finally) solve this problem.

The modifications are the same.