### PR TITLE
ci: update GitHub actions workflow

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -6,15 +6,15 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
       with:
         node-version: '12.x'
     - name: Get npm cache directory
       id: npm-cache
       run: |
         echo "::set-output name=dir::$(npm config get cache)"
-    - uses: actions/cache@v1
+    - uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920  # tag: v3.2.4
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
Updates and pins SHAs for actions. Should clear deprecation warnings on workflow runs.