### PR TITLE
ci: update usage of deprecated ::set-output

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -1,5 +1,6 @@
 name: Auto-update ABI JSON file
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 * * * *'
 jobs:
@@ -13,7 +14,7 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache
       run: |
-        echo "::set-output name=dir::$(npm config get cache)"
+        echo "name=dir::$(npm config get cache)" >> $GITHUB_OUTPUT
     - uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920  # tag: v3.2.4
       with:
         path: ${{ steps.npm-cache.outputs.dir }}


### PR DESCRIPTION
Changed as per these instructions: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/