### PR TITLE
chore: use main branch with cdn.jsdelivr.net for shorter caching

### DIFF
--- a/scripts/update-abi-registry.js
+++ b/scripts/update-abi-registry.js
@@ -14,7 +14,7 @@ async function fetchElectronReleases () {
 }
 
 async function fetchNodeVersions () {
-  const schedule = await getJSONFromCDN('nodejs/Release/schedule.json')
+  const schedule = await getJSONFromCDN('nodejs/Release@main/schedule.json')
   const versions = {}
 
   for (const [majorVersion, metadata] of Object.entries(schedule)) {
@@ -35,7 +35,7 @@ async function fetchNodeVersions () {
 }
 
 async function fetchAbiVersions () {
-  return (await getJSONFromCDN('nodejs/node/doc/abi_version_registry.json'))
+  return (await getJSONFromCDN('nodejs/node@main/doc/abi_version_registry.json'))
     .NODE_MODULE_VERSION
     .filter(({ modules }) => modules > 66)
 }


### PR DESCRIPTION
Per documentation (https://github.com/jsdelivr/jsdelivr#caching), the default URL (alias for `@latest`) caches for 7 days, while specifying branches only caches for 12 hours.