### PR TITLE
build: secondary sort abi_registry.json entries by version

### DIFF
--- a/abi_registry.json
+++ b/abi_registry.json
@@ -110,14 +110,14 @@
     "future": false,
     "lts": false,
     "runtime": "electron",
-    "target": "8.0.0-beta.1"
+    "target": "9.0.0-beta.1"
   },
   {
     "abi": "76",
     "future": false,
     "lts": false,
     "runtime": "electron",
-    "target": "9.0.0-beta.1"
+    "target": "8.0.0-beta.1"
   },
   {
     "abi": "80",
@@ -131,14 +131,14 @@
     "future": false,
     "lts": false,
     "runtime": "electron",
-    "target": "10.0.0-beta.1"
+    "target": "11.0.0-beta.1"
   },
   {
     "abi": "82",
     "future": false,
     "lts": false,
     "runtime": "electron",
-    "target": "11.0.0-beta.1"
+    "target": "10.0.0-beta.1"
   },
   {
     "abi": "85",
@@ -159,13 +159,6 @@
     "future": false,
     "lts": false,
     "runtime": "electron",
-    "target": "13.0.0-beta.2"
-  },
-  {
-    "abi": "89",
-    "future": false,
-    "lts": false,
-    "runtime": "electron",
     "target": "15.0.0-alpha.1"
   },
   {
@@ -174,6 +167,13 @@
     "lts": false,
     "runtime": "electron",
     "target": "14.0.0-beta.1"
+  },
+  {
+    "abi": "89",
+    "future": false,
+    "lts": false,
+    "runtime": "electron",
+    "target": "13.0.0-beta.2"
   },
   {
     "abi": "97",

--- a/scripts/update-abi-registry.js
+++ b/scripts/update-abi-registry.js
@@ -3,6 +3,22 @@ const path = require('path')
 const semver = require('semver')
 const { writeFile } = require('fs').promises
 
+function sortByElectronVersionFn (a, b) {
+  const modulesComp = Number(a.modules) - Number(b.modules)
+  if (modulesComp !== 0) return modulesComp
+  if (semver.lt(a.version, b.version)) return 1
+  if (semver.gt(a.version, b.version)) return -1
+  return 0
+}
+
+function sortByNodeVersionFn (a, b) {
+  const abiComp = Number(a.abi) - Number(b.abi)
+  if (abiComp !== 0) return abiComp
+  if (semver.lt(a.target, b.target)) return 1
+  if (semver.gt(a.target, b.target)) return -1
+  return 0
+}
+
 async function getJSONFromCDN (urlPath) {
   const response = await got(`https://cdn.jsdelivr.net/gh/${urlPath}`)
   return JSON.parse(response.body)
@@ -49,7 +65,7 @@ function electronReleasesToTargets (releases) {
       modules,
     }))
     .filter(({ version }) => !version.includes('nightly'))
-    .sort((a, b) => Number(a.modules) - Number(b.modules))
+    .sort(sortByElectronVersionFn)
     .reduce(
       (acc, { modules, version }) => ({
         ...acc,
@@ -99,7 +115,7 @@ function nodeVersionsToTargets (abiVersions, nodeVersions) {
         },
         {}
       )
-  )
+  ).sort(sortByNodeVersionFn)
 }
 
 async function main () {


### PR DESCRIPTION
The last couple of automated releases didn't have any content change, but were triggered by the sorting order of `abi_registry.json` changing. Enforce a stable ordering by first sorting by ABI (current behavior) and then also sort by version (new behavior).

There should be no user facing changes as a result of this PR - the public API does its own sorting, this only affects the on-disk sorting of `abi_registry.json` as that's what causes new releases to trigger, when that changes.

Considered changing the sorting to be only by version, but that resulted in too much change to `abi_registry.json`. This change results in a minimal diff that is easy to verify by hand.