### PR TITLE
ci: use GitHub app for commits

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -1,16 +1,26 @@
 name: Auto-update ABI JSON file
+
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 * * * *'
+
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
+    - name: Generate GitHub App token
+      uses: electron/github-app-auth-action@72247c8be59cd63accc5f99599bf400a360a5d8a # v1.1.0
+      id: generate-token
+      with:
+        creds: ${{ secrets.GH_APP_CREDS }}
+        export-git-user: true
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+      with:
+        token: ${{ steps.generate-token.outputs.token }}
     - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
       with:
-        node-version: '12.x'
+        node-version: '18.x'
     - name: Get npm cache directory
       id: npm-cache
       run: |
@@ -25,15 +35,9 @@ jobs:
     - name: Update ABI registry
       run: npm run update-abi-registry
     - name: Commit Changes to ABI registry
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
-        chmod 600 ~/.netrc
         git add abi_registry.json
         if test -n "$(git status -s)"; then
-          git config user.name "GitHub Actions"
-          git config user.email "github-actions@users.noreply.github.com"
           git diff --cached
           git commit -m "feat: update ABI registry"
           git push origin HEAD:$GITHUB_REF


### PR DESCRIPTION
Same changes as https://github.com/electron/download-stats/pull/31 and bumps the Node.js version as well.