### PR TITLE
ci: restrict auto-update to more active time window

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -3,7 +3,7 @@ name: Auto-update ABI JSON file
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 15-3 * * *'
+    - cron: '0 15-23,0-3 * * *'
 
 jobs:
   autoupdate:

--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -3,7 +3,7 @@ name: Auto-update ABI JSON file
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 15-3 * * *'
 
 jobs:
   autoupdate:


### PR DESCRIPTION
Since this repo has CFA releases, it's not very useful to us if the auto-update triggers a release when no one is around to approve it. Since most core maintainers are online during US daytime hours, limit the auto-update to running between 8 AM and 8 PM PT.