### PR TITLE
ci: update check-electron-abi workflow

### DIFF
--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -33,6 +33,7 @@ jobs:
           const nodeAbi = require('node-abi');
 
           const abi = nodeAbi.getAbi('${{ github.event.inputs.electron-version }}', 'electron');
+          console.log('Got ABI:', abi);
 
           if (abi !== ${{ github.event.inputs.expected-abi }}) {
             process.exit = 1;

--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -34,7 +34,7 @@ jobs:
 
           const abi = nodeAbi.getAbi('${{ github.event.inputs.electron-version }}', 'electron');
 
-          if (abi !== ${{ github.event.inputs.expected-abi }}) {
+          if (abi !== '${{ github.event.inputs.expected-abi }}') {
             core.error(`Got ABI ${abi}, expected ${{ github.event.inputs.expected-abi }}`);
             process.exitCode = 1;
           } else {

--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -6,6 +6,7 @@ on:
       electron-version:
         type: string
         description: Electron version to check (e.g. 26.0.0)
+        required: true
 
 permissions: {}
 
@@ -14,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Node.js
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
+      uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # tag: v4.0.0
       with:
-        node-version: 18.x
+        node-version: lts/*
     - name: Create a Temporary package.json
       run: npm init --yes
     - name: Install latest node-abi

--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -7,6 +7,10 @@ on:
         type: string
         description: Electron version to check (e.g. 26.0.0)
         required: true
+      expected-abi:
+        type: string
+        description: Expected ABI number (e.g. 117)
+        required: true
 
 permissions: {}
 
@@ -23,4 +27,13 @@ jobs:
     - name: Install latest node-abi
       run: npm install --save-dev node-abi
     - name: Check ABI for Electron version
-      run: node -e "const nodeAbi = require('node-abi'); console.log(nodeAbi.getAbi('${{ github.event.inputs.electron-version }}', 'electron'))"
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+      with:
+        script: |
+          const nodeAbi = require('node-abi');
+
+          const abi = nodeAbi.getAbi('${{ github.event.inputs.electron-version }}', 'electron');
+
+          if (abi !== ${{ github.event.inputs.expected-abi }}) {
+            process.exit = 1;
+          }

--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -33,8 +33,10 @@ jobs:
           const nodeAbi = require('node-abi');
 
           const abi = nodeAbi.getAbi('${{ github.event.inputs.electron-version }}', 'electron');
-          console.log('Got ABI:', abi);
 
           if (abi !== ${{ github.event.inputs.expected-abi }}) {
+            core.error(`Got ABI ${abi}, expected ${{ github.event.inputs.expected-abi }}`);
             process.exitCode = 1;
+          } else {
+            core.info(`Got expected ABI ${abi}`);
           }

--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -36,5 +36,5 @@ jobs:
           console.log('Got ABI:', abi);
 
           if (abi !== ${{ github.event.inputs.expected-abi }}) {
-            process.exit = 1;
+            process.exitCode = 1;
           }


### PR DESCRIPTION
Just some routine maintenance, and marking the input as required which was an oversight in #144.

I've also updated this to take the expected ABI number so we can catch mistakes.