### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/check-electron-abi.yml
+++ b/.github/workflows/check-electron-abi.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Node.js
-      uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65  # tag: v4.0.0
+      uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
       with:
         node-version: lts/*
     - name: Create a Temporary package.json
@@ -27,7 +27,7 @@ jobs:
     - name: Install latest node-abi
       run: npm install --save-dev node-abi
     - name: Check ABI for Electron version
-      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
           const nodeAbi = require('node-abi');

--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -15,17 +15,17 @@ jobs:
       with:
         creds: ${{ secrets.GH_APP_CREDS }}
         export-git-user: true
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         token: ${{ steps.generate-token.outputs.token }}
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
+    - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - name: Get npm cache directory
       id: npm-cache
       run: |
         echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-    - uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920  # tag: v3.2.4
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}


### PR DESCRIPTION
Bumps versions to get things off EOL Node.js versions and preempts deprecation warnings.