### PR TITLE
ci: make signed commits

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -14,7 +14,6 @@ jobs:
       id: generate-token
       with:
         creds: ${{ secrets.GH_APP_CREDS }}
-        export-git-user: true
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         token: ${{ steps.generate-token.outputs.token }}
@@ -33,14 +32,12 @@ jobs:
           ${{ runner.os }}-node-
     - run: npm install --no-package-lock
     - name: Update ABI registry
-      run: npm run update-abi-registry
-    - name: Commit Changes to ABI registry
       run: |
+        npm run update-abi-registry
         git add abi_registry.json
-        if test -n "$(git status -s)"; then
-          git diff --cached
-          git commit -m "feat: update ABI registry"
-          git push origin HEAD:$GITHUB_REF
-        else
-          echo No update needed
-        fi
+    - name: Commit Changes to ABI registry
+      uses: dsanders11/github-app-commit-action@1dd0a2d22c564461d3f598b6858856e8842d7a16 # v1.1.0
+      with:
+        fail-on-no-changes: false
+        message: 'feat: update ABI registry'
+        token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Uses the new `dsanders11/github-app-commit-action` to make the commits via the GitHub API which means they'll be marked as verified.