### PR TITLE
ci: restrict auto-update to Monday-Friday

### DIFF
--- a/.github/workflows/update-abi.yml
+++ b/.github/workflows/update-abi.yml
@@ -3,7 +3,7 @@ name: Auto-update ABI JSON file
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 15-23,0-3 * * *'
+    - cron: '0 15-23,0-3 * * 1-5'
 
 jobs:
   autoupdate:


### PR DESCRIPTION
#149 has worked pretty well, but we should also restrict to workdays for the same reasons.